### PR TITLE
Test allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ services:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: IMAGE_BUILD_PLATFORM=latest-epel-centos7
 
 env:
   - IMAGE_BUILD_PLATFORM=stable-centos7

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -55,6 +55,8 @@
        file: path=/var/log/secure state=touch
      - name: test only - create /var/run/fail2ban for systemd socket file..
        file: path=/var/run/fail2ban state=directory mode=0755
+     - name: test only - sshd host keys must be available for the validate command to run
+       command: ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
 
 
    roles:


### PR DESCRIPTION
This means that travis jobs should now be nice and green in github, but we still test the poorly labeled test "latest-epel-centos7" (which tries to run fgci-ansible playbooks with master of all the roles in requirements.yml - and there are some issues when doing that causing it currently to fail).

Bonus fix: make the sshd role work in docker too. The ansible template module to configure sshd in that role has a validation. And that validation command fails because for some reason there are no sshd host keys generated at that stage. I assume this is a docker issue, but. 

I didn't check if this is an issue for real hardware.