### PR TITLE
Remove ansible from compute kickstart_packages

### DIFF
--- a/examples/group_vars/compute/compute.example
+++ b/examples/group_vars/compute/compute.example
@@ -107,7 +107,6 @@ kickstart_partitions: |
   part /local --fstype="xfs" --ondisk=sda --size=1 --grow
 
 kickstart_packages: |
-  ansible
   atlas
   blas
   bonnie++


### PR DESCRIPTION
As of CentOS 7.4 ansible was moved from the EPEL repo to the CentOS
extras repo. For some reason it doesn't work to add centos extras to
the repo list in kickstart, hence ansible must be installed separately
in the kickstart %post section. It must also be removed from the list
of packages to install in kickstart, which is what this patch does.