### PR TITLE
Kickstart partitioning that works for UEFI too

### DIFF
--- a/examples/group_vars/compute/compute.example
+++ b/examples/group_vars/compute/compute.example
@@ -98,10 +98,11 @@ kickstart_profile: FGCI-compute-node
 # If so, don't forget to add "--grow" in part / line
 
 kickstart_partitions: |
-  bootloader --location=mbr --append="selinux=0" --boot-drive=sda
   zerombr
   clearpart --all --initlabel --drives=sda
+  bootloader --append="selinux=0" --boot-drive=sda
   part biosboot --fstype="biosboot" --size=1
+  part /boot/efi --fstype=efi --label EFI  --size=200
   part / --fstype="xfs" --ondisk=sda --size=200000
   part swap --size=500
   part /local --fstype="xfs" --ondisk=sda --size=1 --grow

--- a/examples/group_vars/login/login.example
+++ b/examples/group_vars/login/login.example
@@ -140,10 +140,11 @@ kickstart_profile: FGCI-login-node
 # If so, don't forget to add "--grow" in part / line
 
 kickstart_partitions: |
-  bootloader --location=mbr --append="selinux=0" --boot-drive=sda
   zerombr
   clearpart --all --initlabel --drives=sda
+  bootloader --append="selinux=0" --boot-drive=sda
   part biosboot --fstype="biosboot" --size=1
+  part /boot/efi --fstype=efi --label EFI  --size=200
   part / --fstype="xfs" --ondisk=sda --size=200000 --grow
   part swap --size=500
   # part /local --fstype="xfs" --ondisk=sda --size=500000

--- a/examples/group_vars/nfs/nfs.example
+++ b/examples/group_vars/nfs/nfs.example
@@ -31,10 +31,12 @@ rdma_configure_single_port: True
 
 kickstart_profile: FGCI-nfs-node
 kickstart_partitions: |
-  bootloader --location=mbr --append="selinux=0" --boot-drive=sda
   zerombr
   clearpart --initlabel --drives=sda --all
+  bootloader --append="selinux=0" --boot-drive=sda
+  part biosboot --fstype="biosboot" --size=1
   part /boot --fstype="ext3" --size=400
+  part /boot/efi --fstype=efi --label EFI  --size=200
   part swap --fstype="swap" --size=10000
   part pv.01 --fstype="lvmpv" --size=1 --grow
   part /scratch --fstype="xfs" --onpart=sdc


### PR DESCRIPTION
For UEFI boot one needs a /boot/efi partition formatted as FAT. Make
sure such a partition is always created. For BIOS boot it makes no
difference.