### PR TITLE
Fix testing with pip - (don't pip install requests[security] )

### DIFF
--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -14,7 +14,8 @@ RUN yum clean all && \
     sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
     pip install --upgrade pip && \
-    pip install requests[security] && \
+    #pip install requests[security] && \
+    pip --version && \
     pip install passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -15,7 +15,7 @@ RUN yum clean all && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
     pip install --upgrade pip && \
     pip install requests[security] && \
-    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    pip install passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \


### PR DESCRIPTION
Before this PR we were seeing errors from PyOpenSSL when pip installing anything with pip 10.0 inside CentOS7 docker container