### PR TITLE
Change remote_tmp to /tmp/.ansible

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,3 +14,4 @@ ansible_managed = Ansible managed file, do not edit directly
 force_handlers = True
 retry_files_enabled = False
 callback_whitelist = profile_tasks
+remote_tmp = /tmp/.ansible


### PR DESCRIPTION
Fixes this:

<pre>
TASK [ansible-role-fgci-install : synchronize group_vars/ to
/var/www/html/group_vars/ - for ansible-pull - secrets and firewalls are
not needed] ****************************
Thursday 31 May 2018  14:32:53 +0300 (0:00:00.218)       0:00:10.967
**********
fatal: [myserver.example.com]: UNREACHABLE! => {"changed": false,
"msg": "Authentication or permission failure. In some cases, you may
have been able to authenticate and did not have permissions on the
target directory. Consider changing the remote tmp path in ansible.cfg
to a path rooted in \"/tmp\". Failed command was: ( umask 77 && mkdir -p
\"` echo /root/.ansible/tmp/ansible-tmp-1527766374.13-139832550625802
`\" && echo ansible-tmp-1527766374.13-139832550625802=\"` echo
/root/.ansible/tmp/ansible-tmp-1527766374.13-139832550625802 `\" ),
exited with result 1", "unreachable": true}
</pre>