### PR TITLE
Remove scp_if_ssh from ansible config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,5 @@
 [ssh_connection]
 ssh_args = -i ~/.ssh/id_rsa -F ssh.config -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPath=~/.ssh/%h -o ControlPersist=30m
-scp_if_ssh = True
 [defaults]
 roles_path = roles
 library = /usr/share/ansible


### PR DESCRIPTION
As of ansible 2.2, the default value of scp_if_ssh is the new 'smart'
option, meaning it will try both sftp and scp.  In any case, there was
never any particular need to choose a non-default value here.  Thus,
lets just use the default.