### PR TITLE
Bump Lustre role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -173,7 +173,7 @@
 
 - src: https://github.com/mhakala/ansible-role-lustre_client
   path: roles
-  version: 919b7a5640b52e3a0bcc941ad41c64e14f27873d
+  version: 7cc5fe3cec9bfd0ce427d8ed781ca46ee953146a
 
 - src: https://github.com/jabl/ansible-role-pam
   path: roles


### PR DESCRIPTION
Updated:
- Make role work for chroot images
- Fix depreciation warning wrt yum/with_items
- Optionally setup IB partitions for chroot images
- Add .gitignore