### PR TITLE
Update ansible-role-pdsh-genders to v1.3.1

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -155,7 +155,7 @@
 
 - src: https://github.com/jabl/ansible-role-pdsh-genders
   path: roles
-  version: v1.2.5
+  version: v1.3.1
 
 - src: https://github.com/CSCfi/ansible-role-serial-console
   path: roles


### PR DESCRIPTION
Main change is to use pdsh packages from OpenHPC, but other than that
should be no user-visible changes.