### PR TITLE
Allow multiple IP's per interface for IB

### DIFF
--- a/roles/network_interface/templates/infiniband_RedHat.j2
+++ b/roles/network_interface/templates/infiniband_RedHat.j2
@@ -12,13 +12,25 @@ BOOTPROTO=none
 TYPE={{ item.type }}
 {% endif %}
 {% if item.address is defined %}
+{% if item.address is not string %}
+{% for a in item.address %}
+IPADDR{{ loop.index - 1 }}={{ a }}
+{% endfor %}
+{% else %}
 IPADDR={{ item.address }}
+{% endif %}
 {% endif %}
 {% if item.onboot is defined %}
 ONBOOT={{ item.onboot }}
 {% endif %}
 {% if item.netmask is defined %}
+{% if item.netmask is not string %}
+{% for n in item.netmask %}
+NETMASK{{ loop.index - 1 }}={{ n }}
+{% endfor %}
+{% else %}
 NETMASK={{ item.netmask }}
+{% endif %}
 {% endif %}
 {% if item.gateway is defined %}
 GATEWAY={{ item.gateway }}


### PR DESCRIPTION
When using Lustre LNet multi-rail it's still useful to split different
server adapters into separate subnets, but no need to create multiple
pseudo devices on the clients, it suffices to just have multiple IP's
on the same interface.