### PR TITLE
Bump ansible-role-lustre-client version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -173,7 +173,7 @@
 
 - src: https://github.com/mhakala/ansible-role-lustre_client
   path: roles
-  version: df75564caac7ea4070d8bad55916ff46892e852d
+  version: 09318407eb25927d2d8360f28e86921a72d8d1b6
 
 - src: https://github.com/jabl/ansible-role-pam
   path: roles


### PR DESCRIPTION
New version enables use of network device aliases for multi-rail.